### PR TITLE
fix ppx

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -29,6 +29,6 @@
   (reason
    (>= 3.6.0))
   reason-react
+  reason-react-ppx
   rescript-syntax
-  reactjs-jsx-ppx
   (ocaml-lsp-server :with-test)))

--- a/example/dune
+++ b/example/dune
@@ -3,4 +3,4 @@
  (alias example)
  (libraries reshowcase reason-react)
  (preprocess
-  (pps melange.ppx reactjs-jsx-ppx)))
+  (pps melange.ppx reason-react-ppx)))

--- a/reshowcase.opam
+++ b/reshowcase.opam
@@ -14,8 +14,8 @@ depends: [
   "melange" {>= "1.0.0"}
   "reason" {>= "3.6.0"}
   "reason-react"
+  "reason-react-ppx"
   "rescript-syntax"
-  "reactjs-jsx-ppx"
   "ocaml-lsp-server" {with-test}
   "odoc" {with-doc}
 ]

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
 (library
  (name reshowcase)
  (preprocess
-  (pps melange.ppx reactjs-jsx-ppx))
+  (pps melange.ppx reason-react-ppx))
  (libraries reason-react)
  (public_name reshowcase)
  (modes melange))


### PR DESCRIPTION
uses latest `reason-react-ppx` rather than `reactjs-jsx-ppx`.